### PR TITLE
Don't check style in resources that are not on the class path

### DIFF
--- a/org.scalastyle.scalastyleplugin.core/src/org/scalastyle/scalastyleplugin/builder/ScalastyleBuilder.scala
+++ b/org.scalastyle.scalastyleplugin.core/src/org/scalastyle/scalastyleplugin/builder/ScalastyleBuilder.scala
@@ -30,6 +30,9 @@ import org.eclipse.core.resources.IncrementalProjectBuilder
 import org.eclipse.core.resources.ResourcesPlugin
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.ui.texteditor.MarkerUtilities
+
+import org.eclipse.jdt.core.JavaCore
+
 import org.scalastyle.scalastyleplugin.ExceptionUtils.handleException
 import org.scalastyle.scalastyleplugin.config.Persistence
 import org.scalastyle.scalastyleplugin.nature.ScalastyleNature
@@ -180,7 +183,10 @@ class ScalastyleBuilder extends JavaScalastyleBuilder {
 
 trait IFilter {
   def isEnabled(): Boolean = true
-  def accept(resource: IResource): Boolean = "scala" == resource.getFileExtension()
+  def accept(resource: IResource): Boolean = {
+    val prj = JavaCore.create(resource.getProject())
+    prj.isOnClasspath(resource) && "scala" == resource.getFileExtension()
+  }
 }
 
 class EclipseOutput extends Output[EclipseFileSpec] {


### PR DESCRIPTION
Fixed #10. Filter out resources that are not on the class path
of a Java project (class path includes source path). Even though
there are convenient methods on `ScalaProject`, I relied on
`JavaCore` so that I don't introduce a dependency on Scala IDE.

We should probably filter our `derived` resources as well, to provide a poor man's filtering mechanism. I imagine source generators might be adding things to the source path that violate style rules, but that aren't under the control of the programmer. That should be another ticket.
