### PR TITLE
Double-click to edit configurations

### DIFF
--- a/org.scalastyle.scalastyleplugin.core/src/org/scalastyle/scalastyleplugin/SwtUtils.scala
+++ b/org.scalastyle.scalastyleplugin.core/src/org/scalastyle/scalastyleplugin/SwtUtils.scala
@@ -47,6 +47,8 @@ import org.eclipse.swt.widgets.Table
 import org.eclipse.swt.widgets.TableColumn
 import org.eclipse.swt.widgets.Text
 import org.eclipse.swt.SWT
+import org.eclipse.jface.viewers.IDoubleClickListener
+import org.eclipse.jface.viewers.DoubleClickEvent
 
 // scalastyle:off magic.number
 
@@ -193,7 +195,7 @@ object SwtUtils {
   case class DialogColumn[T](name: String, alignment: Int, sorter: TableSorter[T, String], weight: Int, getText: (T) => String)
 
   def table[T](parent: Composite, model: Any, columns: List[DialogColumn[T]], contentProvider: IStructuredContentProvider,
-                  labelProvider: ITableLabelProvider, setSelection: (T) => Unit, refresh: => Unit,
+                  labelProvider: ITableLabelProvider, setSelection: (T) => Unit, refresh: => Unit, dblClick: => Unit,
                   layoutData: Any = new GridData(GridData.FILL_BOTH)): TableViewer = {
     val table = new Table(parent, SWT.BORDER | SWT.SINGLE | SWT.FULL_SELECTION)
     table.setLayoutData(layoutData)
@@ -224,6 +226,11 @@ object SwtUtils {
       }
     });
 
+    tableViewer.addDoubleClickListener(new IDoubleClickListener {
+      override def doubleClick(event: DoubleClickEvent) {
+        dblClick
+      }
+    })
     tableViewer
   }
 

--- a/org.scalastyle.scalastyleplugin.core/src/org/scalastyle/scalastyleplugin/preferences/ScalastyleConfigurationDialog.scala
+++ b/org.scalastyle.scalastyleplugin.core/src/org/scalastyle/scalastyleplugin/preferences/ScalastyleConfigurationDialog.scala
@@ -155,7 +155,7 @@ class ScalastyleConfigurationDialog(parent: Shell, filename: String) extends Tit
     tableGridData.grabExcessHorizontalSpace = true
 
     tableViewer = table(checkerGroup, model, columns, new ModelContentProvider[ModelChecker](model),
-                        new PropertiesLabelProvider(columns), setSelection, refresh, layoutData = tableGridData)
+                        new PropertiesLabelProvider(columns), setSelection, refresh, editChecker(currentSelection), layoutData = tableGridData)
 
     editButton = button(contents, "Edit", false, { editChecker(currentSelection) })
 

--- a/org.scalastyle.scalastyleplugin.core/src/org/scalastyle/scalastyleplugin/preferences/ScalastylePreferencePage.scala
+++ b/org.scalastyle.scalastyleplugin.core/src/org/scalastyle/scalastyleplugin/preferences/ScalastylePreferencePage.scala
@@ -103,7 +103,7 @@ class ScalastylePreferencePage extends PreferencePage with IWorkbenchPreferenceP
     tableGridData.horizontalAlignment = GridData.FILL;
 
     tableViewer = table(configurationsGroup, model, columns, new ModelContentProvider(model),
-        new PropertiesLabelProvider(columns), setSelection, refresh, layoutData = tableGridData)
+        new PropertiesLabelProvider(columns), setSelection, refresh, editConfiguration(currentSelection), layoutData = tableGridData)
 
     val browseButton = button(configurationsGroup, "Browse/Add", true, {
       browseForFile(this.getShell(), "Select a scalastyle configuration file") match {


### PR DESCRIPTION
Allow users to double-click table rows in order to
open the corresponding configuration dialog.
