### PR TITLE
Prevent style check of derived resources

### DIFF
--- a/org.scalastyle.scalastyleplugin.core/src/org/scalastyle/scalastyleplugin/builder/ScalastyleBuilder.scala
+++ b/org.scalastyle.scalastyleplugin.core/src/org/scalastyle/scalastyleplugin/builder/ScalastyleBuilder.scala
@@ -185,7 +185,9 @@ trait IFilter {
   def isEnabled(): Boolean = true
   def accept(resource: IResource): Boolean = {
     val prj = JavaCore.create(resource.getProject())
-    prj.isOnClasspath(resource) && "scala" == resource.getFileExtension()
+    prj.isOnClasspath(resource) && 
+      "scala" == resource.getFileExtension() && 
+      !resource.isDerived(IResource.CHECK_ANCESTORS)
   }
 }
 


### PR DESCRIPTION
If project has derived resources they should not be checked. For example in plays generated routing code violates rules all the time. Simple solution is to mark these resouces derived in eclipse.
